### PR TITLE
Upgrade rake version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Dradis Framework 3.16 (February, 2020) ##
+
+*  Upgrade rake version.
+
 ## Dradis Framework 3.15 (November, 2019) ##
 
 *  No changes.

--- a/dradis-saint.gemspec
+++ b/dradis-saint.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'dradis-plugins', '~> 3.8'
   s.add_dependency 'nokogiri'
-  s.add_dependency 'rake', '~> 12.0'
+  s.add_dependency 'rake', '~> 13.0'
 
   s.add_development_dependency 'bundler', '~> 1.6'
   s.add_dependency 'combustion', '~> 0.6.0'


### PR DESCRIPTION
### Summary

Upgrade rake version to be compatible with the Dradis rails upgrade.

### Copyright assignment

Collaboration is difficult with commercial closed source but we want
to keep as much of the OSS ethos as possible available to users
who want to fix it themselves.

In order to unambiguously own and sell Dradis Framework commercial
products, we must have the copyright associated with the entire
codebase. Any code you create which is merged must be owned by us.
That's not us trying to be a jerks, that's just the way it works.

Please review the [CONTRIBUTING.md](https://github.com/dradis/dradis-ce/blob/master/CONTRIBUTING.md)
file for the details.

You can delete this section, but the following sentence needs to
remain in the PR's description:

> I assign all rights, including copyright, to any future Dradis
> work by myself to Security Roots.
