### PR TITLE
Fix/gemspec dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+v4.17.0 (Month 2025)
+  - Move dev gems to the dev dependency
+
 v4.16.0 (May 2025)
   - No changes
 

--- a/dradis-saint.gemspec
+++ b/dradis-saint.gemspec
@@ -22,6 +22,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'rake', '~> 13.0'
 
   spec.add_development_dependency 'bundler', '~> 2.0'
-  spec.add_dependency 'combustion', '~> 0.6.0'
-  spec.add_dependency 'rspec-rails'
+  spec.add_development_dependency 'combustion', '~> 0.6.0'
+  spec.add_development_dependency 'rspec-rails'
 end


### PR DESCRIPTION
### Summary

`combustion` and `rspec` should be dev dependency gems


### Check List

- [ ] Added a CHANGELOG entry
- [ ] Added specs
